### PR TITLE
fix panic when powerdns server is down and tidy up errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ Enable in systemctl
 
 ```systemctl enable pdns-stats-proxy```
 
+# PowerDNS Support
+
+* 4.0
+* 4.1
+* 4.2
+* 4.3


### PR DESCRIPTION
* recover from a panic if the http server in powerdns is down
* tidy up errors so that they are not duplicated between the Poll() and DNSWorker() outputs.