### PR TITLE
fix race in log configuration for testing)

### DIFF
--- a/cmd/pdns-statsd-proxy/pdns.go
+++ b/cmd/pdns-statsd-proxy/pdns.go
@@ -54,19 +54,19 @@ func (pdns *pdnsClient) Worker(config *Config) {
 		case <-interval.C:
 			response, err := pdns.Poll()
 			if err != nil {
-				log.Warn("powerdns client",
+				log.Error("powerdns client",
 					zap.Error(err),
 				)
 				continue
 			}
 			err = decodeStats(response, config)
 			if err != nil {
-				log.Warn("powerdns decodeStats",
+				log.Error("powerdns decodeStats",
 					zap.Error(err),
 				)
 			}
 		case <-config.pdnsDone:
-			log.Warn("exiting from pdns Worker.")
+			log.Info("exiting from pdns Worker.")
 			close(config.pdnsDone)
 			return
 		}
@@ -78,7 +78,7 @@ func (pdns *pdnsClient) Poll() (*http.Response, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if err, ok := r.(error); ok {
-				log.Warn("recovered from panic in pdnsClient.Polll()",
+				log.Error("recovered from panic in pdnsClient.Polll()",
 					zap.Error(err),
 				)
 			}

--- a/cmd/pdns-statsd-proxy/stats.go
+++ b/cmd/pdns-statsd-proxy/stats.go
@@ -59,7 +59,7 @@ func StatsWorker(config *Config) {
 		case s := <-config.StatsChan:
 			err := processStats(s)
 			if err != nil {
-				log.Warn("error submitting statistics",
+				log.Error("error submitting statistics",
 					zap.String("metric_name", s.Name),
 					zap.String("host", *config.statsHost),
 					zap.String("port", *config.statsPort),
@@ -69,11 +69,11 @@ func StatsWorker(config *Config) {
 		case <-config.statsDone:
 			err := stats.Close()
 			if err != nil {
-				log.Warn("unable to cleanly close statsd buffer",
+				log.Error("unable to cleanly close statsd buffer",
 					zap.Error(err),
 				)
 			}
-			log.Warn("exiting from StatsWorker.")
+			log.Info("exiting from StatsWorker.")
 			close(config.statsDone)
 			close(config.StatsChan)
 			return
@@ -86,7 +86,7 @@ func processStats(s Statistic) error {
 	defer func() {
 		if r := recover(); r != nil {
 			if err, ok := r.(error); ok {
-				log.Info("recovered from panic in statsd processStats()",
+				log.Error("recovered from panic in statsd processStats()",
 					zap.Error(err),
 				)
 			}


### PR DESCRIPTION
* tests had a race where the log global was configured multiple times resulting in a crash
* update logging so that the output levels are consistent