### PR TITLE
CVE-2020-14040 - fix CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,15 @@
 module github.com/jimmystewpot/pdns-statsd-proxy
 
-go 1.15
+go 1.16
 
 require (
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/quipo/statsd v0.0.0-20180118161217-3d6a5565f314
+	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
-	go.uber.org/zap v1.16.1-0.20210518180053-374825111f7f
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	go.uber.org/zap v1.19.1-0.20210813012313-d8fd848d18f2
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace golang.org/x/text => golang.org/x/text v0.3.7
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20210812204632-0ba0e8f03122


### PR DESCRIPTION
Update zap and add replace statements to override vulnerabilities in golang/x libraries.